### PR TITLE
Add more vue bootstrap table features

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -60,6 +60,10 @@ var index = {
             type: String,
             required: false,
         },
+        id: {
+            type: String,
+            required: false,
+        }
     },
 
     render(h, {props, listeners, scopedSlots}) {
@@ -115,63 +119,91 @@ var index = {
             });
         }
 
-        const tableheader = h('thead', [
-            h('tr', [
+        const tableheader = h('thead', {attrs: {role: "rowgroup"}}, [
+            h('tr', {attrs: {role: 'row'}}, [
                 fields.map(field => {
+                    let className = field.thClass
+                        ? typeof field.thClass == 'function'
+                            ? field.thClass(field.key)
+                            : field.thClass
+                        : '';
+
+                    if (Array.isArray(className)) {
+                        className = className.join(' ');
+                    }
+
+                    className = ('header ' + className).trim();
+
+                    const args = {attrs: {class: className, role: 'columnheader'}};
+
+                    if (scopedSlots['head']) {
+                        return h('th', args, [
+                            scopedSlots['head'](field),
+                        ]);
+                    }
+
                     let fieldContainsLabel = Object.prototype.hasOwnProperty.call(field, 'label');
-                    return h('th', {attrs: {class: 'header'}}, [
+                    return h('th', args, [
                         h('div', [fieldContainsLabel ? field.label : field.key]),
                     ]);
                 }),
             ]),
         ]);
+
         const tableRows = items.map(item => {
             const cells = fields.map(field => {
                 // TODO :: improve on this
-                let className = field.tdClass ? field.tdClass(item[field.key], field.key, item) : '';
+                let className = field.tdClass
+                    ? typeof field.tdClass == 'function'
+                        ? field.tdClass(item[field.key], field.key, item)
+                        : field.tdClass
+                    : '';
 
-                if (field.formatter) {
-                    return h(
-                        'td',
-                        {
-                            on: {
-                                click: () => {
-                                    if (listeners['row-clicked']) listeners['row-clicked'](item);
-                                },
-                            },
-                            attrs: {
-                                class: className,
-                            },
-                        },
-                        [field.formatter(item[field.key], field.key, item)]
-                    );
+                if (Array.isArray(className)) {
+                    className = className.join(' ');
                 }
 
-                if (scopedSlots[`cell(${field.key})`]) {
-                    return h('td', {attrs: {class: className}}, [
-                        h('slot', [h('div', scopedSlots[`cell(${field.key})`](item))]),
-                    ]);
-                }
-                return h(
-                    'td',
-                    {
-                        on: {
-                            click: () => {
-                                if (listeners['row-clicked']) listeners['row-clicked'](item);
-                            },
-                        },
-                        attrs: {
-                            class: className,
+                const args = {
+                    on: {
+                        click: () => {
+                            if (listeners['row-clicked']) listeners['row-clicked'](item);
                         },
                     },
-                    item[field.key]
-                );
+                    attrs: {
+                        role: 'cell',
+                        class: className,
+                    },
+                };
+
+                if (field.formatter) {
+                    return h('td', args, [field.formatter(item[field.key], field.key, item)]);
+                }
+
+                const scopedField = scopedSlots[`cell(${field.key})`] || scopedSlots[`cell()`] || scopedSlots[`cell`];
+                if (scopedField) {
+                    if (item instanceof Object) {
+                        item.__key = field.key;
+                        if (!item.key) {
+                            item.key = field.key;
+                        }
+                    }
+
+                    return h('td', args, [
+                        h('slot', [h('div', scopedField(item))]),
+                    ]);
+                }
+                return h('td', args, item[field.key]);
             });
-            return h('tr', [cells]);
+            return h('tr', {attrs: {role: 'row'}}, [cells]);
         });
 
-        const tableBody = h('tbody', [tableRows]);
-        const minimalTable = h('table', {attrs: {class: tableClassName}}, [[tableheader], [tableBody]]);
+        const tableBody = h('tbody', {attrs: {role: 'rowgroup'}}, [tableRows]);
+        const minimalTable = h('table', {
+            attrs: {
+                class: tableClassName,
+                id: props.id,
+            }
+        }, [[tableheader], [tableBody]]);
 
         return h('div', {attrs: {class: 'table-responsive'}}, [minimalTable]);
     },

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,6 +62,10 @@ var index = {
             type: String,
             required: false,
         },
+        id: {
+            type: String,
+            required: false,
+        }
     },
 
     render(h, {props, listeners, scopedSlots}) {
@@ -117,63 +121,91 @@ var index = {
             });
         }
 
-        const tableheader = h('thead', [
-            h('tr', [
+        const tableheader = h('thead', {attrs: {role: "rowgroup"}}, [
+            h('tr', {attrs: {role: 'row'}}, [
                 fields.map(field => {
+                    let className = field.thClass
+                        ? typeof field.thClass == 'function'
+                            ? field.thClass(field.key)
+                            : field.thClass
+                        : '';
+
+                    if (Array.isArray(className)) {
+                        className = className.join(' ');
+                    }
+
+                    className = ('header ' + className).trim();
+
+                    const args = {attrs: {class: className, role: 'columnheader'}};
+
+                    if (scopedSlots['head']) {
+                        return h('th', args, [
+                            scopedSlots['head'](field),
+                        ]);
+                    }
+
                     let fieldContainsLabel = Object.prototype.hasOwnProperty.call(field, 'label');
-                    return h('th', {attrs: {class: 'header'}}, [
+                    return h('th', args, [
                         h('div', [fieldContainsLabel ? field.label : field.key]),
                     ]);
                 }),
             ]),
         ]);
+
         const tableRows = items.map(item => {
             const cells = fields.map(field => {
                 // TODO :: improve on this
-                let className = field.tdClass ? field.tdClass(item[field.key], field.key, item) : '';
+                let className = field.tdClass
+                    ? typeof field.tdClass == 'function'
+                        ? field.tdClass(item[field.key], field.key, item)
+                        : field.tdClass
+                    : '';
 
-                if (field.formatter) {
-                    return h(
-                        'td',
-                        {
-                            on: {
-                                click: () => {
-                                    if (listeners['row-clicked']) listeners['row-clicked'](item);
-                                },
-                            },
-                            attrs: {
-                                class: className,
-                            },
-                        },
-                        [field.formatter(item[field.key], field.key, item)]
-                    );
+                if (Array.isArray(className)) {
+                    className = className.join(' ');
                 }
 
-                if (scopedSlots[`cell(${field.key})`]) {
-                    return h('td', {attrs: {class: className}}, [
-                        h('slot', [h('div', scopedSlots[`cell(${field.key})`](item))]),
-                    ]);
-                }
-                return h(
-                    'td',
-                    {
-                        on: {
-                            click: () => {
-                                if (listeners['row-clicked']) listeners['row-clicked'](item);
-                            },
-                        },
-                        attrs: {
-                            class: className,
+                const args = {
+                    on: {
+                        click: () => {
+                            if (listeners['row-clicked']) listeners['row-clicked'](item);
                         },
                     },
-                    item[field.key]
-                );
+                    attrs: {
+                        role: 'cell',
+                        class: className,
+                    },
+                };
+
+                if (field.formatter) {
+                    return h('td', args, [field.formatter(item[field.key], field.key, item)]);
+                }
+
+                const scopedField = scopedSlots[`cell(${field.key})`] || scopedSlots[`cell()`] || scopedSlots[`cell`];
+                if (scopedField) {
+                    if (item instanceof Object) {
+                        item.__key = field.key;
+                        if (!item.key) {
+                            item.key = field.key;
+                        }
+                    }
+
+                    return h('td', args, [
+                        h('slot', [h('div', scopedField(item))]),
+                    ]);
+                }
+                return h('td', args, item[field.key]);
             });
-            return h('tr', [cells]);
+            return h('tr', {attrs: {role: 'row'}}, [cells]);
         });
 
-        const tableBody = h('tbody', [tableRows]);
-        const minimalTable = h('table', {attrs: {class: tableClassName}}, [[tableheader], [tableBody]]);
+        const tableBody = h('tbody', {attrs: {role: 'rowgroup'}}, [tableRows]);
+        const minimalTable = h('table', {
+            attrs: {
+                class: tableClassName,
+                id: props.id,
+            }
+        }, [[tableheader], [tableBody]]);
 
         return h('div', {attrs: {class: 'table-responsive'}}, [minimalTable]);
     },

--- a/src/index.js
+++ b/src/index.js
@@ -122,15 +122,7 @@ export default {
         const tableheader = h('thead', {attrs: {role: 'rowgroup'}}, [
             h('tr', {attrs: {role: 'row'}}, [
                 fields.map(field => {
-                    let className = field.thClass
-                        ? typeof field.thClass == 'function'
-                            ? field.thClass(field.key)
-                            : field.thClass
-                        : '';
-
-                    if (Array.isArray(className)) {
-                        className = className.join(' ');
-                    }
+                    let className = parseClasses(field.thClass);
 
                     className = ('header ' + className).trim();
 
@@ -149,11 +141,7 @@ export default {
         const tableRows = items.map(item => {
             const cells = fields.map(field => {
                 // TODO :: improve on this
-                let className = field.tdClass
-                    ? typeof field.tdClass == 'function'
-                        ? field.tdClass(item[field.key], field.key, item)
-                        : field.tdClass
-                    : '';
+                let className = parseClasses(field.tdClass);
 
                 if (Array.isArray(className)) {
                     className = className.join(' ');
@@ -205,4 +193,14 @@ export default {
 
         return h('div', {attrs: {class: 'table-responsive'}}, [minimalTable]);
     },
+};
+
+const parseClasses = input => {
+    className = input ? (typeof input == 'function' ? input(item[field.key], field.key, item) : input) : '';
+
+    if (Array.isArray(className)) {
+        className = className.join(' ');
+    }
+
+    return className;
 };


### PR DESCRIPTION
This adds:
- id prop that can be assigned to the table
- catch all slot for table rows (`cell` and `cell()`)
- header content can now be controlled via a slot (`header`)
- add bootstrap roles to the elements
- tdClass property can now be a function returning a string, function returning an array, array and string
- added thClass for adding classes to the header with the same features as tdClass
- add __key (and key if possible) property to cell data argument