### PR TITLE
Add context and general optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,44 @@
-Vue Fast Table
+# Vue Fast Table
 
-Vue Fast Table is a functional component for displaying tabular data. It is designed as a functional component written in Javascript to be used with VueJS. Currently, it supports the following props: 
+Vue Fast Table is a component for displaying tabular data. Currently, it supports the following props:
 
-# Fields
-Fields is an array that contains objects used to build the table. Each individual field can contain a key, used to identify a value in an item, and a label that is used to generate the table's headers. 
+## Getting started:
 
-Example: 
+```html
+<VueFastTable :fields="fields" :items="items" />
+
+<script>
+    import VueFastTable from '@script-development/vue-fast-table';
+
+    export default {
+        components: {
+            VueFastTable,
+        },
+        data() {
+            return {
+                fields: [
+                    {key: 'name', label: 'Name'},
+                    {key: 'dob', label: 'Date of birth'},
+                ],
+                items: [
+                    {name: 'Harry', dob: '14-03-1948'},
+                    {name: 'Sally', dob: '19-11-1961'},
+                ],
+            };
+        },
+    };
+</script>
+```
+
+## Props
+
+### Fields
+
+Fields is an array that contains objects used to build the table. Each individual field can contain a key, used to identify a value in an item, and a label that is used to generate the table's headers.
+
+Example:
+
+```js
 fields = [
     {
         key: 'first_name',
@@ -13,92 +46,98 @@ fields = [
     },
     {
         key: 'dob',
-        label: 'Date of birth'
-    }
-]
+        label: 'Date of birth',
+    },
+];
+```
 
 The array above will generate a table containing two rows, one displaying "Name" and the other displaying "Date of birth".
 
-# Items
+### Items
 
 The actual table data is contained in items. An array of items can look like this:
+
+```js
 items = [
-{
-    first_name: 'Harry',
-    dob: '14-03-1948'
-},
-{
-    first_name: 'Sally',
-    dob: '19-11-1961'
-}
-]
+    {
+        first_name: 'Harry',
+        dob: '14-03-1948',
+    },
+    {
+        first_name: 'Sally',
+        dob: '19-11-1961',
+    },
+];
+```
 
 When combined with the fields defined above, this will result in a table that looks like this:
 
-Name    Date of birth
-Harry   14-03-1948
-Sally   19-11-1961
+| Name  | Date of birth |
+| ----- | ------------- |
+| Harry | 14-03-1948    |
+| Sally | 19-11-1961    |
 
 An item may also contain a formatter. A formatter is a function that can be used to dynamically alter data. We could, for example, add a formatter to the fields we defined earlier:
 
+```js
 items = [
     {
         key: 'first_name',
         label: 'Name',
         formatter: (name, first_name, item) => {
-            return first_name + ' is a name'
-        }
+            return first_name + ' is a name';
+        },
     },
     {
         key: 'dob',
-        label: 'Date of birth'
-    }
-]
+        label: 'Date of birth',
+    },
+];
+```
 
 This results in the following table:
 
-Name              Date of birth
-Harry is a name   14-03-1948
-Sally is a name   19-11-1961
+| Name            | Date of birth |
+| --------------- | ------------- |
+| Harry is a name | 14-03-1948    |
+| Sally is a name | 19-11-1961    |
 
 Finally, a tdClass can be added to items to specify a class for a td. An example:
 tdClass
+
+```js
 fields = [
     {
         key: 'first_name',
         label: 'Name',
-        tdClass: 'blue'
+        tdClass: 'blue',
     },
     {
         key: 'dob',
-        label: 'Date of birth'
-    }
-]
+        label: 'Date of birth',
+    },
+];
+```
 
 When the tdClass has been defined like this, all td's in the 'Name' row will have a classname 'blue'. A tdClass can also be generated dynamically:
+
+```js
 fields = [
     {
         key: 'first_name',
         label: 'Name',
-        tdClass: (name, first_name, items) =>  {
+        tdClass: (name, first_name, items) => {
             if (name.startsWith('S')) {
                 return 'Sally';
-            } 
+            }
             return Harry;
-        }
+        },
     },
     {
         key: 'dob',
-        label: 'Date of birth'
-    }
-]
+        label: 'Date of birth',
+    },
+];
+```
 
-In this scenario, all cells containing a name starting with S will have the class 'Sally' and all other cells will have the class 'Harry'. 
-
-
-
-
-
-
-
-
+In this scenario, all cells containing a name starting with S will have the class 'Sally' and all other cells will have the class 'Harry'.

--- a/dev/style.css
+++ b/dev/style.css
@@ -3,5 +3,5 @@
 }
 
 .exclusive_test {
-    background-color: red; 
+    background-color: red;
 }

--- a/dist/Cell.vue.d.ts
+++ b/dist/Cell.vue.d.ts
@@ -1,0 +1,25 @@
+import { PropType } from 'vue';
+import { Field, Item } from './types';
+declare const _default: {
+    name: string;
+    props: {
+        item: {
+            type: PropType<Item>;
+            required: boolean;
+        };
+        field: {
+            type: PropType<Field>;
+            required: boolean;
+        };
+        getContext: {
+            type: PropType<(_item: Item) => string>;
+            default: any;
+        };
+    };
+    computed: {
+        formatted(): any;
+        extendedItem(): any;
+        classes(): any;
+    };
+};
+export default _default;

--- a/dist/Component.vue.d.ts
+++ b/dist/Component.vue.d.ts
@@ -1,7 +1,11 @@
 import { PropType } from 'vue';
 import { Field, Item } from './types';
+import Cell from './Cell.vue';
 declare const _default: {
     name: string;
+    components: {
+        Cell: import("vue").VueConstructor<Cell>;
+    };
     props: {
         items: {
             type: PropType<Item[]>;
@@ -55,28 +59,29 @@ declare const _default: {
             type: BooleanConstructor;
             default: boolean;
         };
+        getContext: {
+            type: PropType<(_item: Item) => string>;
+            default: any;
+        };
     };
     data(): {
         sortedItems: Item[];
     };
     computed: {
         tableClassName(): string;
+        headSlotName(): "head()" | "head";
     };
     watch: {
         items(): void;
-        sortBy(): void;
-        sort(): void;
+        sortBy(newVal: any, oldVal: any): void;
+        sort(newVal: any, oldVal: any): void;
         fields(): void;
     };
     beforeMount(): void;
     methods: {
-        getItemBindingData(item: Item, field: Field): {
-            __key: string;
-            __id?: string | number;
-            formatter?: (_item: Item) => any;
-        };
+        getSlotName(item: Item): any;
         sortItems(): void;
-        parseClasses(input: string | string[] | ((_item?: Item) => string | string[]), item?: Item): string;
+        parseClasses(input: (() => string | string[]) | string | string[]): string;
     };
 };
 export default _default;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,5 @@
 import Component from './Component.vue';
 export default Component;
 export * from './types';
+export declare const VueFastTable: import("vue").VueConstructor<Component>;
+export declare const InternalCell: import("vue").VueConstructor<Component>;

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,140 +1,49 @@
-const propToClassKeys = ['borderless', 'hover', 'outlined', 'bordered', 'striped', 'dark', 'small', 'busy'];
-var script = {
-    name: 'VueFastTable',
+var script$1 = {
+    name: 'Cell',
     props: {
-        items: {
-            type: Array,
-            default: () => [],
+        item: {
+            type: Object,
+            required: true,
         },
-        fields: {
-            type: Array,
-            default: () => [],
+        field: {
+            type: Object,
+            required: true,
         },
-        borderless: {
-            type: Boolean,
-            default: true,
-        },
-        hover: {
-            type: Boolean,
-            default: false,
-        },
-        outlined: {
-            type: Boolean,
-            default: false,
-        },
-        bordered: {
-            type: Boolean,
-            default: false,
-        },
-        striped: {
-            type: Boolean,
-            default: false,
-        },
-        dark: {
-            type: Boolean,
-            default: false,
-        },
-        small: {
-            type: Boolean,
-            default: false,
-        },
-        sort: {
-            type: String,
-            default: 'ascending',
-        },
-        sortBy: {
-            type: String,
+        getContext: {
+            type: Function,
             default: undefined,
         },
-        id: {
-            type: String,
-            default: undefined,
-        },
-        busy: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    data() {
-        return {
-            sortedItems: [],
-        };
     },
     computed: {
-        tableClassName() {
-            let tableClassName = 'table b-table';
-            for (const key of propToClassKeys) {
-                const value = this[key];
-                if (value) {
-                    tableClassName += ' table-' + (key == 'small' ? 'sm' : key);
-                }
+        formatted() {
+            return this.field.formatter(this.extendedItem);
+        },
+        extendedItem() {
+            var _a;
+            const item = Object.assign({}, this.item);
+            item.__key = this.field.key;
+            if (this.getContext) {
+                item.__context = this.getContext(item);
             }
-            return tableClassName;
-        },
-    },
-    watch: {
-        items() {
-            this.sortItems();
-        },
-        sortBy() {
-            this.sortItems();
-        },
-        sort() {
-            this.sortItems();
-        },
-        fields() {
-            this.sortItems();
-        },
-    },
-    beforeMount() {
-        this.sortItems();
-    },
-    methods: {
-        getItemBindingData(item, field) {
-            return Object.assign(Object.assign({}, item), { __key: field.key });
-        },
-        sortItems() {
-            const items = [...this.items];
-            if (this.sortBy && items.length > 1) {
-                items.sort((a, b) => {
-                    const field = this.fields.find(f => f.key === this.sortBy);
-                    let item1, item2;
-                    if (field && field.formatter) {
-                        item1 = field.formatter(a[this.sortBy], this.sortBy, a);
-                        item2 = field.formatter(b[this.sortBy], this.sortBy, b);
-                    }
-                    else if (typeof a[this.sortBy] === 'string') {
-                        item1 = a[this.sortBy].toUpperCase();
-                        item2 = b[this.sortBy].toUpperCase();
-                    }
-                    else {
-                        item1 = a[this.sortBy];
-                        item2 = b[this.sortBy];
-                    }
-                    let comparison = 0;
-                    if (item1 > item2) {
-                        comparison = 1;
-                    }
-                    else if (item2 > item1) {
-                        comparison = -1;
-                    }
-                    else {
-                        comparison = 0;
-                    }
-                    if (this.sort == 'descending') {
-                        comparison *= -1;
-                    }
-                    return comparison;
-                });
+            else if ((_a = this.field) === null || _a === void 0 ? void 0 : _a.getContext) {
+                item.__context = this.field.getContext(item);
             }
-            this.sortedItems = items.map((item, idx) => (Object.assign({ __id: idx }, item)));
+            else if (item === null || item === void 0 ? void 0 : item.getContext) {
+                item.__context = item.getContext(item);
+            }
+            return item;
         },
-        parseClasses(input, item) {
-            let className = input ? (typeof input == 'function' ? input(item) : input) : '';
+        classes() {
+            const tdClass = this.field.tdClass;
+            const item = this.extendedItem;
+            let className = tdClass ? (typeof tdClass == 'function' ? tdClass(item) : tdClass) : '';
             if (Array.isArray(className)) {
                 className = className.join(' ');
             }
-            return className;
+            if (item.__context) {
+                className += ` context_${item.__context}`;
+            }
+            return className.trim();
         },
     },
 };
@@ -215,6 +124,243 @@ function normalizeComponent(template, style, script, scopeId, isFunctionalTempla
 }
 
 /* script */
+const __vue_script__$1 = script$1;
+
+/* template */
+var __vue_render__$1 = function() {
+  var _vm = this;
+  var _h = _vm.$createElement;
+  var _c = _vm._self._c || _h;
+  return _c(
+    "td",
+    {
+      class: _vm.classes,
+      attrs: { role: "cell" },
+      on: {
+        click: function($event) {
+          return _vm.$emit("click", _vm.extendedItem)
+        },
+        dblclick: function($event) {
+          return _vm.$emit("dblclick", _vm.extendedItem)
+        }
+      }
+    },
+    [
+      _vm.field.formatter
+        ? [_vm._v("\n        " + _vm._s(_vm.formatted) + "\n    ")]
+        : _vm._t("default", null, null, _vm.extendedItem)
+    ],
+    2
+  )
+};
+var __vue_staticRenderFns__$1 = [];
+__vue_render__$1._withStripped = true;
+
+  /* style */
+  const __vue_inject_styles__$1 = undefined;
+  /* scoped */
+  const __vue_scope_id__$1 = undefined;
+  /* module identifier */
+  const __vue_module_identifier__$1 = undefined;
+  /* functional template */
+  const __vue_is_functional_template__$1 = false;
+  /* style inject */
+  
+  /* style inject SSR */
+  
+  /* style inject shadow dom */
+  
+
+  
+  const __vue_component__$1 = /*#__PURE__*/normalizeComponent(
+    { render: __vue_render__$1, staticRenderFns: __vue_staticRenderFns__$1 },
+    __vue_inject_styles__$1,
+    __vue_script__$1,
+    __vue_scope_id__$1,
+    __vue_is_functional_template__$1,
+    __vue_module_identifier__$1,
+    false,
+    undefined,
+    undefined,
+    undefined
+  );
+
+const propToClassKeys = ['borderless', 'hover', 'outlined', 'bordered', 'striped', 'dark', 'small', 'busy'];
+var script = {
+    name: 'VueFastTable',
+    components: { Cell: __vue_component__$1 },
+    props: {
+        items: {
+            type: Array,
+            default: () => [],
+        },
+        fields: {
+            type: Array,
+            default: () => [],
+        },
+        borderless: {
+            type: Boolean,
+            default: true,
+        },
+        hover: {
+            type: Boolean,
+            default: false,
+        },
+        outlined: {
+            type: Boolean,
+            default: false,
+        },
+        bordered: {
+            type: Boolean,
+            default: false,
+        },
+        striped: {
+            type: Boolean,
+            default: false,
+        },
+        dark: {
+            type: Boolean,
+            default: false,
+        },
+        small: {
+            type: Boolean,
+            default: false,
+        },
+        sort: {
+            type: String,
+            default: 'ascending',
+        },
+        sortBy: {
+            type: String,
+            default: undefined,
+        },
+        id: {
+            type: String,
+            default: undefined,
+        },
+        busy: {
+            type: Boolean,
+            default: false,
+        },
+        getContext: {
+            type: Function,
+            default: undefined,
+        },
+    },
+    data() {
+        return {
+            sortedItems: [],
+        };
+    },
+    computed: {
+        tableClassName() {
+            let tableClassName = 'table b-table';
+            for (const key of propToClassKeys) {
+                const value = this[key];
+                if (value) {
+                    tableClassName += ' table-' + (key == 'small' ? 'sm' : key);
+                }
+            }
+            return tableClassName;
+        },
+        headSlotName() {
+            return this.$scopedSlots['head()'] ? 'head()' : 'head';
+        },
+    },
+    watch: {
+        items() {
+            this.sortItems();
+        },
+        sortBy(newVal, oldVal) {
+            if (newVal != oldVal) {
+                this.sortItems();
+            }
+        },
+        sort(newVal, oldVal) {
+            if (newVal != oldVal) {
+                this.sortItems();
+            }
+        },
+        fields() {
+            this.sortItems();
+        },
+    },
+    beforeMount() {
+        this.sortItems();
+    },
+    methods: {
+        getSlotName(item) {
+            let name;
+            const context = item.__context;
+            if (context) {
+                name = `cell(${item.__key})@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+            }
+            name = `cell(${item.__key})`;
+            if (this.$scopedSlots[name]) {
+                return name;
+            }
+            if (context) {
+                name = `cell()@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+                name = `cell@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+            }
+            return this.$scopedSlots[`cell()`] ? `cell()` : `cell`;
+        },
+        sortItems() {
+            const items = [...this.items];
+            if (this.sortBy && items.length > 1) {
+                items.sort((a, b) => {
+                    const field = this.fields.find(f => f.key === this.sortBy);
+                    let item1, item2;
+                    if (field && field.formatter) {
+                        item1 = field.formatter(a[this.sortBy], this.sortBy, a);
+                        item2 = field.formatter(b[this.sortBy], this.sortBy, b);
+                    }
+                    else if (typeof a[this.sortBy] === 'string') {
+                        item1 = a[this.sortBy].toUpperCase();
+                        item2 = b[this.sortBy].toUpperCase();
+                    }
+                    else {
+                        item1 = a[this.sortBy];
+                        item2 = b[this.sortBy];
+                    }
+                    let comparison = 0;
+                    if (item1 > item2) {
+                        comparison = 1;
+                    }
+                    else if (item2 > item1) {
+                        comparison = -1;
+                    }
+                    else {
+                        comparison = 0;
+                    }
+                    if (this.sort == 'descending') {
+                        comparison *= -1;
+                    }
+                    return comparison;
+                });
+            }
+            this.sortedItems = items.map((item, idx) => (Object.assign({ __id: idx }, item)));
+        },
+        parseClasses(input) {
+            let className = input ? (typeof input == 'function' ? input() : input) : '';
+            if (Array.isArray(className)) {
+                className = className.join(' ');
+            }
+            return className.trim();
+        },
+    },
+};
+
+/* script */
 const __vue_script__ = script;
 
 /* template */
@@ -238,22 +384,15 @@ var __vue_render__ = function() {
               },
               [
                 _vm._t(
-                  "head",
+                  _vm.headSlotName,
                   [
-                    _vm._t(
-                      "head()",
-                      [
-                        _c("div", [
-                          _vm._v(
-                            "\n                                " +
-                              _vm._s(field.label || field.key) +
-                              "\n                            "
-                          )
-                        ])
-                      ],
-                      null,
-                      field
-                    )
+                    _c("div", [
+                      _vm._v(
+                        "\n                            " +
+                          _vm._s(field.label || field.key) +
+                          "\n                        "
+                      )
+                    ])
                   ],
                   null,
                   field
@@ -310,49 +449,49 @@ var __vue_render__ = function() {
                     }
                   },
                   _vm._l(_vm.fields, function(field) {
-                    return _c(
-                      "td",
-                      {
-                        key: field.key,
-                        class: _vm.parseClasses(field.tdClass, item),
-                        attrs: { role: "cell" }
+                    return _c("Cell", {
+                      key: field.key,
+                      attrs: {
+                        item: item,
+                        field: field,
+                        "get-context": _vm.getContext
                       },
-                      [
-                        _vm._t(
-                          "cell(" + field.key + ")",
-                          [
-                            _vm._t(
-                              "cell()",
-                              [
+                      on: {
+                        click: function($event) {
+                          return _vm.$emit("cell-click", $event)
+                        },
+                        dblclick: function($event) {
+                          return _vm.$emit("cell-dblclick", $event)
+                        }
+                      },
+                      scopedSlots: _vm._u(
+                        [
+                          {
+                            key: "default",
+                            fn: function(extendedItem) {
+                              return [
                                 _vm._t(
-                                  "cell",
+                                  _vm.getSlotName(extendedItem),
                                   [
                                     _vm._v(
-                                      "\n                                " +
-                                        _vm._s(
-                                          field.formatter
-                                            ? field.formatter(item)
-                                            : item[field.key]
-                                        ) +
-                                        "\n                            "
+                                      "\n                            " +
+                                        _vm._s(item[field.key] || "") +
+                                        "\n                        "
                                     )
                                   ],
                                   null,
-                                  _vm.getItemBindingData(item, field)
+                                  extendedItem
                                 )
-                              ],
-                              null,
-                              _vm.getItemBindingData(item, field)
-                            )
-                          ],
-                          null,
-                          _vm.getItemBindingData(item, field)
-                        )
-                      ],
-                      2
-                    )
+                              ]
+                            }
+                          }
+                        ],
+                        null,
+                        true
+                      )
+                    })
                   }),
-                  0
+                  1
                 )
               })
         ],
@@ -407,4 +546,8 @@ __vue_render__._withStripped = true;
     undefined
   );
 
+const VueFastTable = __vue_component__;
+const InternalCell = __vue_component__$1;
+
 export default __vue_component__;
+export { InternalCell, VueFastTable };

--- a/dist/index.ssr.js
+++ b/dist/index.ssr.js
@@ -1,142 +1,53 @@
 'use strict';
 
-const propToClassKeys = ['borderless', 'hover', 'outlined', 'bordered', 'striped', 'dark', 'small', 'busy'];
-var script = {
-    name: 'VueFastTable',
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var script$1 = {
+    name: 'Cell',
     props: {
-        items: {
-            type: Array,
-            default: () => [],
+        item: {
+            type: Object,
+            required: true,
         },
-        fields: {
-            type: Array,
-            default: () => [],
+        field: {
+            type: Object,
+            required: true,
         },
-        borderless: {
-            type: Boolean,
-            default: true,
-        },
-        hover: {
-            type: Boolean,
-            default: false,
-        },
-        outlined: {
-            type: Boolean,
-            default: false,
-        },
-        bordered: {
-            type: Boolean,
-            default: false,
-        },
-        striped: {
-            type: Boolean,
-            default: false,
-        },
-        dark: {
-            type: Boolean,
-            default: false,
-        },
-        small: {
-            type: Boolean,
-            default: false,
-        },
-        sort: {
-            type: String,
-            default: 'ascending',
-        },
-        sortBy: {
-            type: String,
+        getContext: {
+            type: Function,
             default: undefined,
         },
-        id: {
-            type: String,
-            default: undefined,
-        },
-        busy: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    data() {
-        return {
-            sortedItems: [],
-        };
     },
     computed: {
-        tableClassName() {
-            let tableClassName = 'table b-table';
-            for (const key of propToClassKeys) {
-                const value = this[key];
-                if (value) {
-                    tableClassName += ' table-' + (key == 'small' ? 'sm' : key);
-                }
+        formatted() {
+            return this.field.formatter(this.extendedItem);
+        },
+        extendedItem() {
+            var _a;
+            const item = Object.assign({}, this.item);
+            item.__key = this.field.key;
+            if (this.getContext) {
+                item.__context = this.getContext(item);
             }
-            return tableClassName;
-        },
-    },
-    watch: {
-        items() {
-            this.sortItems();
-        },
-        sortBy() {
-            this.sortItems();
-        },
-        sort() {
-            this.sortItems();
-        },
-        fields() {
-            this.sortItems();
-        },
-    },
-    beforeMount() {
-        this.sortItems();
-    },
-    methods: {
-        getItemBindingData(item, field) {
-            return Object.assign(Object.assign({}, item), { __key: field.key });
-        },
-        sortItems() {
-            const items = [...this.items];
-            if (this.sortBy && items.length > 1) {
-                items.sort((a, b) => {
-                    const field = this.fields.find(f => f.key === this.sortBy);
-                    let item1, item2;
-                    if (field && field.formatter) {
-                        item1 = field.formatter(a[this.sortBy], this.sortBy, a);
-                        item2 = field.formatter(b[this.sortBy], this.sortBy, b);
-                    }
-                    else if (typeof a[this.sortBy] === 'string') {
-                        item1 = a[this.sortBy].toUpperCase();
-                        item2 = b[this.sortBy].toUpperCase();
-                    }
-                    else {
-                        item1 = a[this.sortBy];
-                        item2 = b[this.sortBy];
-                    }
-                    let comparison = 0;
-                    if (item1 > item2) {
-                        comparison = 1;
-                    }
-                    else if (item2 > item1) {
-                        comparison = -1;
-                    }
-                    else {
-                        comparison = 0;
-                    }
-                    if (this.sort == 'descending') {
-                        comparison *= -1;
-                    }
-                    return comparison;
-                });
+            else if ((_a = this.field) === null || _a === void 0 ? void 0 : _a.getContext) {
+                item.__context = this.field.getContext(item);
             }
-            this.sortedItems = items.map((item, idx) => (Object.assign({ __id: idx }, item)));
+            else if (item === null || item === void 0 ? void 0 : item.getContext) {
+                item.__context = item.getContext(item);
+            }
+            return item;
         },
-        parseClasses(input, item) {
-            let className = input ? (typeof input == 'function' ? input(item) : input) : '';
+        classes() {
+            const tdClass = this.field.tdClass;
+            const item = this.extendedItem;
+            let className = tdClass ? (typeof tdClass == 'function' ? tdClass(item) : tdClass) : '';
             if (Array.isArray(className)) {
                 className = className.join(' ');
             }
-            return className;
+            if (item.__context) {
+                className += ` context_${item.__context}`;
+            }
+            return className.trim();
         },
     },
 };
@@ -217,6 +128,243 @@ function normalizeComponent(template, style, script, scopeId, isFunctionalTempla
 }
 
 /* script */
+const __vue_script__$1 = script$1;
+
+/* template */
+var __vue_render__$1 = function() {
+  var _vm = this;
+  var _h = _vm.$createElement;
+  var _c = _vm._self._c || _h;
+  return _c(
+    "td",
+    {
+      class: _vm.classes,
+      attrs: { role: "cell" },
+      on: {
+        click: function($event) {
+          return _vm.$emit("click", _vm.extendedItem)
+        },
+        dblclick: function($event) {
+          return _vm.$emit("dblclick", _vm.extendedItem)
+        }
+      }
+    },
+    [
+      _vm.field.formatter
+        ? [_vm._v("\n        " + _vm._s(_vm.formatted) + "\n    ")]
+        : _vm._t("default", null, null, _vm.extendedItem)
+    ],
+    2
+  )
+};
+var __vue_staticRenderFns__$1 = [];
+__vue_render__$1._withStripped = true;
+
+  /* style */
+  const __vue_inject_styles__$1 = undefined;
+  /* scoped */
+  const __vue_scope_id__$1 = undefined;
+  /* module identifier */
+  const __vue_module_identifier__$1 = undefined;
+  /* functional template */
+  const __vue_is_functional_template__$1 = false;
+  /* style inject */
+  
+  /* style inject SSR */
+  
+  /* style inject shadow dom */
+  
+
+  
+  const __vue_component__$1 = /*#__PURE__*/normalizeComponent(
+    { render: __vue_render__$1, staticRenderFns: __vue_staticRenderFns__$1 },
+    __vue_inject_styles__$1,
+    __vue_script__$1,
+    __vue_scope_id__$1,
+    __vue_is_functional_template__$1,
+    __vue_module_identifier__$1,
+    false,
+    undefined,
+    undefined,
+    undefined
+  );
+
+const propToClassKeys = ['borderless', 'hover', 'outlined', 'bordered', 'striped', 'dark', 'small', 'busy'];
+var script = {
+    name: 'VueFastTable',
+    components: { Cell: __vue_component__$1 },
+    props: {
+        items: {
+            type: Array,
+            default: () => [],
+        },
+        fields: {
+            type: Array,
+            default: () => [],
+        },
+        borderless: {
+            type: Boolean,
+            default: true,
+        },
+        hover: {
+            type: Boolean,
+            default: false,
+        },
+        outlined: {
+            type: Boolean,
+            default: false,
+        },
+        bordered: {
+            type: Boolean,
+            default: false,
+        },
+        striped: {
+            type: Boolean,
+            default: false,
+        },
+        dark: {
+            type: Boolean,
+            default: false,
+        },
+        small: {
+            type: Boolean,
+            default: false,
+        },
+        sort: {
+            type: String,
+            default: 'ascending',
+        },
+        sortBy: {
+            type: String,
+            default: undefined,
+        },
+        id: {
+            type: String,
+            default: undefined,
+        },
+        busy: {
+            type: Boolean,
+            default: false,
+        },
+        getContext: {
+            type: Function,
+            default: undefined,
+        },
+    },
+    data() {
+        return {
+            sortedItems: [],
+        };
+    },
+    computed: {
+        tableClassName() {
+            let tableClassName = 'table b-table';
+            for (const key of propToClassKeys) {
+                const value = this[key];
+                if (value) {
+                    tableClassName += ' table-' + (key == 'small' ? 'sm' : key);
+                }
+            }
+            return tableClassName;
+        },
+        headSlotName() {
+            return this.$scopedSlots['head()'] ? 'head()' : 'head';
+        },
+    },
+    watch: {
+        items() {
+            this.sortItems();
+        },
+        sortBy(newVal, oldVal) {
+            if (newVal != oldVal) {
+                this.sortItems();
+            }
+        },
+        sort(newVal, oldVal) {
+            if (newVal != oldVal) {
+                this.sortItems();
+            }
+        },
+        fields() {
+            this.sortItems();
+        },
+    },
+    beforeMount() {
+        this.sortItems();
+    },
+    methods: {
+        getSlotName(item) {
+            let name;
+            const context = item.__context;
+            if (context) {
+                name = `cell(${item.__key})@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+            }
+            name = `cell(${item.__key})`;
+            if (this.$scopedSlots[name]) {
+                return name;
+            }
+            if (context) {
+                name = `cell()@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+                name = `cell@${context}`;
+                if (this.$scopedSlots[name]) {
+                    return name;
+                }
+            }
+            return this.$scopedSlots[`cell()`] ? `cell()` : `cell`;
+        },
+        sortItems() {
+            const items = [...this.items];
+            if (this.sortBy && items.length > 1) {
+                items.sort((a, b) => {
+                    const field = this.fields.find(f => f.key === this.sortBy);
+                    let item1, item2;
+                    if (field && field.formatter) {
+                        item1 = field.formatter(a[this.sortBy], this.sortBy, a);
+                        item2 = field.formatter(b[this.sortBy], this.sortBy, b);
+                    }
+                    else if (typeof a[this.sortBy] === 'string') {
+                        item1 = a[this.sortBy].toUpperCase();
+                        item2 = b[this.sortBy].toUpperCase();
+                    }
+                    else {
+                        item1 = a[this.sortBy];
+                        item2 = b[this.sortBy];
+                    }
+                    let comparison = 0;
+                    if (item1 > item2) {
+                        comparison = 1;
+                    }
+                    else if (item2 > item1) {
+                        comparison = -1;
+                    }
+                    else {
+                        comparison = 0;
+                    }
+                    if (this.sort == 'descending') {
+                        comparison *= -1;
+                    }
+                    return comparison;
+                });
+            }
+            this.sortedItems = items.map((item, idx) => (Object.assign({ __id: idx }, item)));
+        },
+        parseClasses(input) {
+            let className = input ? (typeof input == 'function' ? input() : input) : '';
+            if (Array.isArray(className)) {
+                className = className.join(' ');
+            }
+            return className.trim();
+        },
+    },
+};
+
+/* script */
 const __vue_script__ = script;
 
 /* template */
@@ -240,22 +388,15 @@ var __vue_render__ = function() {
               },
               [
                 _vm._t(
-                  "head",
+                  _vm.headSlotName,
                   [
-                    _vm._t(
-                      "head()",
-                      [
-                        _c("div", [
-                          _vm._v(
-                            "\n                                " +
-                              _vm._s(field.label || field.key) +
-                              "\n                            "
-                          )
-                        ])
-                      ],
-                      null,
-                      field
-                    )
+                    _c("div", [
+                      _vm._v(
+                        "\n                            " +
+                          _vm._s(field.label || field.key) +
+                          "\n                        "
+                      )
+                    ])
                   ],
                   null,
                   field
@@ -312,49 +453,49 @@ var __vue_render__ = function() {
                     }
                   },
                   _vm._l(_vm.fields, function(field) {
-                    return _c(
-                      "td",
-                      {
-                        key: field.key,
-                        class: _vm.parseClasses(field.tdClass, item),
-                        attrs: { role: "cell" }
+                    return _c("Cell", {
+                      key: field.key,
+                      attrs: {
+                        item: item,
+                        field: field,
+                        "get-context": _vm.getContext
                       },
-                      [
-                        _vm._t(
-                          "cell(" + field.key + ")",
-                          [
-                            _vm._t(
-                              "cell()",
-                              [
+                      on: {
+                        click: function($event) {
+                          return _vm.$emit("cell-click", $event)
+                        },
+                        dblclick: function($event) {
+                          return _vm.$emit("cell-dblclick", $event)
+                        }
+                      },
+                      scopedSlots: _vm._u(
+                        [
+                          {
+                            key: "default",
+                            fn: function(extendedItem) {
+                              return [
                                 _vm._t(
-                                  "cell",
+                                  _vm.getSlotName(extendedItem),
                                   [
                                     _vm._v(
-                                      "\n                                " +
-                                        _vm._s(
-                                          field.formatter
-                                            ? field.formatter(item)
-                                            : item[field.key]
-                                        ) +
-                                        "\n                            "
+                                      "\n                            " +
+                                        _vm._s(item[field.key] || "") +
+                                        "\n                        "
                                     )
                                   ],
                                   null,
-                                  _vm.getItemBindingData(item, field)
+                                  extendedItem
                                 )
-                              ],
-                              null,
-                              _vm.getItemBindingData(item, field)
-                            )
-                          ],
-                          null,
-                          _vm.getItemBindingData(item, field)
-                        )
-                      ],
-                      2
-                    )
+                              ]
+                            }
+                          }
+                        ],
+                        null,
+                        true
+                      )
+                    })
                   }),
-                  0
+                  1
                 )
               })
         ],
@@ -409,4 +550,9 @@ __vue_render__._withStripped = true;
     undefined
   );
 
-module.exports = __vue_component__;
+const VueFastTable = __vue_component__;
+const InternalCell = __vue_component__$1;
+
+exports.InternalCell = InternalCell;
+exports.VueFastTable = VueFastTable;
+exports.default = __vue_component__;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,9 +1,15 @@
 export interface Item {
     __id?: number | string;
+    __key?: string;
+    __context?: string;
     formatter?: (_item: Item) => any;
+    getContext?: (_item: Item) => string;
+    [key: string]: any;
 }
 export interface Field {
     key?: string;
     thClass?: (() => string[] | string) | string | string[];
     tdClass?: ((_item: Item) => string[] | string) | string | string[];
+    getContext?: (_item: Item) => string;
+    [key: string]: any;
 }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -10,7 +10,7 @@ export default [
                 // SSR build.
                 file: pkg.main,
                 format: 'cjs',
-                exports: 'auto',
+                exports: 'named',
             },
             {
                 // ESM build to be used with webpack/rollup.

--- a/src/Cell.vue
+++ b/src/Cell.vue
@@ -1,0 +1,74 @@
+<template>
+    <td
+        role="cell"
+        :class="classes"
+        @click="$emit('click', extendedItem)"
+        @dblclick="$emit('dblclick', extendedItem)"
+    >
+        <template v-if="field.formatter">
+            {{ formatted }}
+        </template>
+        <slot
+            v-else
+            name="default"
+            v-bind="extendedItem"
+        />
+    </td>
+</template>
+
+<script lang="ts">
+import {PropType} from 'vue';
+import {Field, Item} from './types';
+
+export default {
+    name: 'Cell',
+    props: {
+        item: {
+            type: Object as PropType<Item>,
+            required: true,
+        },
+        field: {
+            type: Object as PropType<Field>,
+            required: true,
+        },
+        getContext: {
+            type: Function as PropType<(_item: Item) => string>,
+            default: undefined,
+        },
+    },
+    computed: {
+        formatted() {
+            return this.field.formatter(this.extendedItem);
+        },
+        extendedItem() {
+            const item = {...this.item};
+            item.__key = this.field.key;
+
+            if (this.getContext) {
+                item.__context = this.getContext(item);
+            } else if (this.field?.getContext) {
+                item.__context = this.field.getContext(item);
+            } else if (item?.getContext) {
+                item.__context = item.getContext(item);
+            }
+
+            return item;
+        },
+        classes() {
+            const tdClass = this.field.tdClass;
+            const item = this.extendedItem;
+
+            let className = tdClass ? (typeof tdClass == 'function' ? tdClass(item) : tdClass) : '';
+            if (Array.isArray(className)) {
+                className = className.join(' ');
+            }
+
+            if (item.__context) {
+                className += ` context_${item.__context}`;
+            }
+
+            return className.trim();
+        },
+    },
+};
+</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 import Component from './Component.vue';
+import Cell from './Cell.vue';
 export default Component;
 
 export * from './types';
+
+export const VueFastTable = Component;
+export const InternalCell = Cell;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,39 @@
 export interface Item {
+    // A internal property we use to track the position of an item in a table using the vue :key property
     __id?: number | string;
+
+    // Contains the field it's key
+    // This property will be set automatically
+    __key?: string;
+
+    // Might contain the Item's context based on it's context
+    // This value is mainly for internal use
+    __context?: string;
+
+    // Format the content of the item
     formatter?: (_item: Item) => any;
+
+    // provide a item with a context (ONLY ALPHABETIC CHARACTERS AND _)
+    // The __key will contain the field key
+    getContext?: (_item: Item) => string;
+
+    // The item it's data
+    [key: string]: any;
 }
 
 export interface Field {
+    // This field identifier
     key?: string;
+
+    // Class(es) to add to every th element
     thClass?: (() => string[] | string) | string | string[];
+
+    // Class(es) to add to every td element
     tdClass?: ((_item: Item) => string[] | string) | string | string[];
+
+    // provide a item with a context (ONLY ALPHABETIC CHARACTERS AND _)
+    getContext?: (_item: Item) => string;
+
+    // Extra field data
+    [key: string]: any;
 }


### PR DESCRIPTION
- Add `GetContext` to props, field and items
- If context are provided support slots based on context, for example `cell(key_of_field)@context_name_here`
- Improved readme readability and added getting started section
- Added wildcard for other fields in `Field` and `Item` type
- Moved a lot of code to `Cell.vue` to make the component load vaster and not to repeat a lot of code
- Added a lot of tests for the scoped slots